### PR TITLE
build: ota: Support for install tools in /tmp/install

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2124,6 +2124,8 @@ ifdef BUILDING_RECOVERY_IMAGE
 
 INTERNAL_RECOVERYIMAGE_FILES := $(filter $(TARGET_RECOVERY_OUT)/%, \
     $(ALL_DEFAULT_INSTALLED_MODULES))
+INTERNAL_RECOVERYIMAGE_FILES += $(filter $(PRODUCT_OUT)/install/%, \
+    $(ALL_DEFAULT_INSTALLED_MODULES))
 
 INSTALLED_FILES_FILE_RECOVERY := $(PRODUCT_OUT)/installed-files-recovery.txt
 INSTALLED_FILES_JSON_RECOVERY := $(INSTALLED_FILES_FILE_RECOVERY:.txt=.json)
@@ -5747,6 +5749,9 @@ ifneq (true,$(BOARD_INCLUDE_RECOVERY_RAMDISK_IN_VENDOR_BOOT))
 	$(hide) $(call package_files-copy-root, \
 	    $(TARGET_RECOVERY_ROOT_OUT),$(zip_root)/$(PRIVATE_RECOVERY_OUT)/RAMDISK)
 endif
+	@# OTA install helpers
+	$(hide) $(call package_files-copy-root, \
+	    $(PRODUCT_OUT)/install,$(zip_root)/INSTALL)
 ifdef INSTALLED_KERNEL_TARGET
 ifneq (,$(filter true,$(BOARD_USES_RECOVERY_AS_BOOT)))
 	cp $(INSTALLED_KERNEL_TARGET) $(zip_root)/$(PRIVATE_RECOVERY_OUT)/

--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -245,6 +245,11 @@ class EdifyGenerator(object):
           p.mount_point, mount_flags))
       self.mounts.add(p.mount_point)
 
+  def UnpackPackageDir(self, src, dst):
+    """Unpack a given directory from the OTA package into the given
+    destination directory."""
+    self.script.append('package_extract_dir("%s", "%s");' % (src, dst))
+
   def Comment(self, comment):
     """Write a comment into the update script."""
     self.script.append("")
@@ -382,6 +387,21 @@ class EdifyGenerator(object):
       if entry is not None:
         assert not entry.slotselect, \
           "Use %s because %s is slot suffixed" % (fn, lst[1])
+
+  def SetPermissionsRecursive(self, fn, uid, gid, dmode, fmode, selabel,
+                              capabilities):
+    """Recursively set path ownership and permissions."""
+    if capabilities is None:
+      capabilities = "0x0"
+    cmd = 'set_metadata_recursive("%s", "uid", %d, "gid", %d, ' \
+        '"dmode", 0%o, "fmode", 0%o' \
+        % (fn, uid, gid, dmode, fmode)
+    if not fn.startswith("/tmp"):
+      cmd += ', "capabilities", "%s"' % capabilities
+    if selabel is not None:
+      cmd += ', "selabel", "%s"' % selabel
+    cmd += ');'
+    self.script.append(cmd)
 
   def WriteRawImage(self, mount_point, fn, mapfn=None):
     """Write the given package file into the partition for the given

--- a/tools/releasetools/non_ab_ota.py
+++ b/tools/releasetools/non_ab_ota.py
@@ -116,6 +116,15 @@ def GetBlockDifferences(target_zip, source_zip, target_info, source_info,
   return block_diff_dict
 
 
+def CopyInstallTools(output_zip):
+  install_path = os.path.join(OPTIONS.input_tmp, "INSTALL")
+  for root, subdirs, files in os.walk(install_path):
+     for f in files:
+      install_source = os.path.join(root, f)
+      install_target = os.path.join("install", os.path.relpath(root, install_path), f)
+      output_zip.write(install_source, install_target)
+
+
 def WriteFullOTAPackage(input_zip, output_file):
   target_info = common.BuildInfo(OPTIONS.info_dict, OPTIONS.oem_dicts)
 
@@ -219,6 +228,11 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   script.Print("            |__/                             ")
   script.Print(" ")
   device_specific.FullOTA_InstallBegin()
+
+  CopyInstallTools(output_zip)
+  script.UnpackPackageDir("install", "/tmp/install")
+  script.SetPermissionsRecursive("/tmp/install", 0, 0, 0o755, 0o644, None, None)
+  script.SetPermissionsRecursive("/tmp/install/bin", 0, 0, 0o755, 0o755, None, None)
 
   # All other partitions as well as the data wipe use 10% of the progress, and
   # the update of the system partition takes the remaining progress.

--- a/tools/releasetools/ota_utils.py
+++ b/tools/releasetools/ota_utils.py
@@ -39,7 +39,7 @@ OPTIONS.boot_variable_file = None
 
 METADATA_NAME = 'META-INF/com/android/metadata'
 METADATA_PROTO_NAME = 'META-INF/com/android/metadata.pb'
-UNZIP_PATTERN = ['IMAGES/*', 'META/*', 'OTA/*', 'RADIO/*']
+UNZIP_PATTERN = ['IMAGES/*', 'INSTALL/*', 'META/*', 'OTA/*', 'RADIO/*']
 SECURITY_PATCH_LEVEL_PROP_NAME = "ro.build.version.security_patch"
 
 


### PR DESCRIPTION
 * Anything in OUT/install gets packaged up into the zip and extracted to /tmp/install immediately after FullOTA_InstallBegin.

 * Use /tmp/install in edify scripts and remove code related to using and manipulating /system for install tools.

 * Modified to support signing steps being split from build steps.

   Package install files into target-files INSTALL path Read from target-files for OTA package creation

   From Change-Id: I64f919c2a757b5474f6cc5f82bd6c33c2a8b558a

 * This also fully reverts commit 6a324ba and partially reverts commit f388104 as the functions are still needed here.

   From Change-Ids: I4911244ec9945d197d2b56d0d11eab6d2f7b6d3e I4943e2e89ee5c810a63746c570dc5e31e95b8c53

Squashed with the following:

Author: LuK1337 <priv.luk@gmail.com>
Date:   Wed Feb 19 02:14:59 2020 +0100
    releasetools: Use 0oXXX instead of 0XXX for octal

    * Fixes py3 syntax error.

    Change-Id: Ia9ca6e392f43694ddf4c952b07bf159e8dead36e

Author: LuK1337 <priv.luk@gmail.com>
Date:   Fri Nov 13 15:27:24 2020 +0100
    Add $(PRODUCT_OUT)/install to INTERNAL_RECOVERYIMAGE_FILES

    * Fixes $(PRODUCT_OUT)/install not being included on targets
      not providing their own /vendor || /system/vendor.

    Change-Id: I15b8305bb7efacfcf3018708bf7ff8b8500744fb

Change-Id: I315a3238e36c8d15e26f935e272f7e27dd59c320